### PR TITLE
Return 404 on a feed where no content is available

### DIFF
--- a/controllers/OnePassController.php
+++ b/controllers/OnePassController.php
@@ -92,6 +92,10 @@ class OnePassController extends BaseController
 
 
 			$latestEntry = $criteria->first();
+			if( !$latestEntry ) {
+				// Return null (404) if nothing was found, because the feed will be empty
+				return null;
+			}
 
 
 			// Get a list of all entries from the section chosen in the plugin settings


### PR DESCRIPTION
Without this check, an error is raised when the plugin tries to access fields on a nonexistent entry
