### PR TITLE
Header fix

### DIFF
--- a/controllers/OnePassController.php
+++ b/controllers/OnePassController.php
@@ -120,8 +120,8 @@ class OnePassController extends BaseController
 			}
 
 
-			if ($currentPage + 1 < $lastPage) {
-				$paginationOptions['next_page_href'] = craft()->getSiteUrl() . 'actions/onePass/feed/?paged=' . ($currentPage + 1);
+			if ($currentPage + 1 <= $lastPage) {
+				$paginationOptions['next_page_href'] = craft()->getSiteUrl() . 'actions/onePass/feed/?page=' . ($currentPage + 1);
 			}
 
 

--- a/controllers/OnePassController.php
+++ b/controllers/OnePassController.php
@@ -61,8 +61,8 @@ class OnePassController extends BaseController
 		// Pass the current URL and the timestamp into the buildHash method of 1pass-client and compare with X-ONEPASS-SIGNATURE to determine whether you should reject or accept the request.
 
 
-		$timestamp = $this->getRequestHeader('X-ONEPASS-TIMESTAMP');
-		$signature = $this->getRequestHeader('X-ONEPASS-SIGNATURE');
+		$timestamp = $this->getRequestHeader('HTTP_X_1PASS_TIMESTAMP');
+		$signature = $this->getRequestHeader('HTTP_X_1PASS_SIGNATURE');
 
 
 		return ($this->publisherAccount->buildHash(craft()->getSiteUrl() . 'actions/onePass/feed', $timestamp) === $signature) ? true : false;


### PR DESCRIPTION
The 1Pass header names were wrong. Our fault: they were wrong in our docs! Fixed at https://github.com/1Pass/1pass-reference/commit/36f90280bbaeb3db7817e0bc208324a33e04f810 

The feed was missing a `rel=next` link param when the next page was the last page, and it was asking for a `paged` rather than `page` param.
